### PR TITLE
Add tests for StringExtentions

### DIFF
--- a/tests/DomainTest/ModuleTests/StringExtentionsTests.cs
+++ b/tests/DomainTest/ModuleTests/StringExtentionsTests.cs
@@ -1,0 +1,18 @@
+using Domain.Modules;
+using Xunit;
+
+namespace DomainTest.ModuleTests
+{
+    public class StringExtentionsTests
+    {
+        [Theory]
+        [InlineData("１２３４５６７８９０", "1234567890")]
+        [InlineData("abc１２３", "abc123")]
+        [InlineData("NoNumbers", "NoNumbers")]
+        public void ConvertFullToHalfNumbers_ShouldConvertCorrectly(string input, string expected)
+        {
+            var result = input.ConvertFullToHalfNumbers();
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for the StringExtentions ConvertFullToHalfNumbers method

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e222ba3c832cadd32f4490886a15