### PR TITLE
Fix typo in StringExtensions class

### DIFF
--- a/src/Domain/Modules/StringExtensions.cs
+++ b/src/Domain/Modules/StringExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Domain.Modules
 {
-    static internal partial class StringExtentions
+    static internal partial class StringExtensions
     {
         /// <summary>
         /// 全角数字を半角数字に変換する。


### PR DESCRIPTION
## Summary
- rename `StringExtentions.cs` to `StringExtensions.cs`
- rename the class to `StringExtensions`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842e38799d4832c882f2164c9e3076d