### PR TITLE
Fix extra semicolons in PlayerScore constructor

### DIFF
--- a/src/Domain/Entities/PlayerScore.cs
+++ b/src/Domain/Entities/PlayerScore.cs
@@ -18,10 +18,10 @@ namespace Domain.Entities
         public PlayerScore(PlayerId playerId, GameMode gameMode, MusicId musicId, Difficulty difficulty, PlayOptionBase playOption, PlayAt playAt, Score score, ClearLamp clearLamp, Memo memo)
         {
             PlayerId = playerId ?? throw new ArgumentNullException(nameof(playerId));
-            GameMode = gameMode ?? throw new ArgumentNullException(nameof(gameMode)); ;
+            GameMode = gameMode ?? throw new ArgumentNullException(nameof(gameMode));
             MusicId = musicId ?? throw new ArgumentNullException(nameof(musicId));
             Difficulty = difficulty ?? throw new ArgumentNullException(nameof(difficulty));
-            PlayOption = playOption ?? throw new ArgumentNullException(nameof(playOption)); ;
+            PlayOption = playOption ?? throw new ArgumentNullException(nameof(playOption));
             PlayAt = playAt ?? throw new ArgumentNullException(nameof(playAt));
             Score = score ?? throw new ArgumentNullException(nameof(score));
             ClearLamp = clearLamp ?? throw new ArgumentNullException(nameof(clearLamp));


### PR DESCRIPTION
## Summary
- fix double `;` after `GameMode` and `PlayOption` assignments in `PlayerScore`

## Testing
- `dotnet build DBRManager.sln -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e398dab0832c960a7c70c71b8024