### PR TITLE
Fix typo in test class name

### DIFF
--- a/tests/DomainTest/ModuleTests/StringExtensionsTests.cs
+++ b/tests/DomainTest/ModuleTests/StringExtensionsTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace DomainTest.ModuleTests
 {
-    public class StringExtentionsTests
+    public class StringExtensionsTests
     {
         [Theory]
         [InlineData("１２３４５６７８９０", "1234567890")]


### PR DESCRIPTION
## Summary
- fix the typo `StringExtentions` -> `StringExtensions`
- update class name to match file name

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ea822810832c84dcbb91155877b3