### PR TITLE
Fix typo in test file name

### DIFF
--- a/tests/DomainTest/ModuleTests/StringExtensionsTests.cs
+++ b/tests/DomainTest/ModuleTests/StringExtensionsTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace DomainTest.ModuleTests
 {
-    public class StringExtentionsTests
+    public class StringExtensionsTests
     {
         [Theory]
         [InlineData("１２３４５６７８９０", "1234567890")]


### PR DESCRIPTION
## Summary
- rename `StringExtentionsTests` to `StringExtensionsTests`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842eb283954832c9906c80a04120ad5