### PR TITLE
Switch Update method back to sync

### DIFF
--- a/src/Domain/Repositories/IRepository.cs
+++ b/src/Domain/Repositories/IRepository.cs
@@ -5,7 +5,7 @@
         Task<IEnumerable<T>> GetAllAsync();
         Task<T> GetByIdAsync(TId id);
         Task AddAsync(T entity);
-        Task UpdateAsync(T entity);
+        void Update(T entity);
         Task DeleteAsync(TId id);
     }
 }

--- a/src/Infrastructure/EFCore/Repository.cs
+++ b/src/Infrastructure/EFCore/Repository.cs
@@ -29,7 +29,7 @@ namespace Infrastructure.Repositories
             await _entities.AddAsync(entity);
         }
 
-        public async Task UpdateAsync(T entity)
+        public void Update(T entity)
         {
             _entities.Update(entity);
         }


### PR DESCRIPTION
## Summary
- rename `UpdateAsync` to `Update` in `IRepository`
- make the base `Repository` implement `Update` synchronously

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e3c03538832c9830a573583b6f8e