### PR TITLE
Fix PlayerScore repository interface and methods

### DIFF
--- a/src/Domain/Repositories/IPlayerScoreRepository.cs
+++ b/src/Domain/Repositories/IPlayerScoreRepository.cs
@@ -5,7 +5,7 @@ namespace Domain.Repositories
 {
     public interface IPlayerScoreRepository : IRepository<PlayerScore, (PlayerId, MusicId, Difficulty, PlayAt)>
     {
-        Task<IEnumerable<PlayerScore>> GetScoresByPlayerIdAsync(Guid playerId);
-        Task<IEnumerable<PlayerScore>> GetScoresByMusicIdAsync(Guid musicId);
+        Task<IEnumerable<PlayerScore>> GetScoresByPlayerIdAsync(PlayerId playerId);
+        Task<IEnumerable<PlayerScore>> GetScoresByMusicIdAsync(MusicId musicId);
     }
 }

--- a/src/Infrastructure/EFCore/PlayerScoreRepository.cs
+++ b/src/Infrastructure/EFCore/PlayerScoreRepository.cs
@@ -1,6 +1,7 @@
 ﻿using Domain.Entities;
 using Domain.Repositories;
 using Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Repositories
 {
@@ -8,24 +9,36 @@ namespace Infrastructure.Repositories
     {
         public PlayerScoreRepository(ApplicationDbContext context) : base(context) { }
 
-        public Task DeleteAsync((PlayerId, MusicId, Difficulty, PlayAt) id)
+        async Task IRepository<PlayerScore, (PlayerId, MusicId, Difficulty, PlayAt)>.DeleteAsync((PlayerId, MusicId, Difficulty, PlayAt) id)
         {
-            throw new NotImplementedException();
+            var entity = await ((IRepository<PlayerScore, (PlayerId, MusicId, Difficulty, PlayAt)>)this).GetByIdAsync(id);
+            if (entity != null)
+            {
+                _context.PlayerScores.Remove(entity);
+            }
         }
 
-        public Task<PlayerScore> GetByIdAsync((PlayerId, MusicId, Difficulty, PlayAt) id)
+        async Task<PlayerScore> IRepository<PlayerScore, (PlayerId, MusicId, Difficulty, PlayAt)>.GetByIdAsync((PlayerId, MusicId, Difficulty, PlayAt) id)
         {
-            throw new NotImplementedException();
+            return await _context.PlayerScores.FirstOrDefaultAsync(ps =>
+                ps.PlayerId == id.Item1 &&
+                ps.MusicId == id.Item2 &&
+                ps.Difficulty == id.Item3 &&
+                ps.PlayAt == id.Item4);
         }
 
-        public Task<IEnumerable<PlayerScore>> GetScoresByMusicIdAsync(Guid musicId)
+        public async Task<IEnumerable<PlayerScore>> GetScoresByMusicIdAsync(MusicId musicId)
         {
-            throw new NotImplementedException();
+            return await _context.PlayerScores
+                .Where(ps => ps.MusicId == musicId)
+                .ToListAsync();
         }
 
-        public Task<IEnumerable<PlayerScore>> GetScoresByPlayerIdAsync(Guid playerId)
+        public async Task<IEnumerable<PlayerScore>> GetScoresByPlayerIdAsync(PlayerId playerId)
         {
-            throw new NotImplementedException();
+            return await _context.PlayerScores
+                .Where(ps => ps.PlayerId == playerId)
+                .ToListAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix `IPlayerScoreRepository` to use `PlayerId` and `MusicId`
- implement `PlayerScoreRepository` methods for composite key retrieval and queries

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842e1c09060832cbef028de0c007cb4