### PR TITLE
Add coverage reporting to GitHub Actions

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -21,5 +21,20 @@ jobs:
     - name: Build
       run: dotnet build --no-restore DBRManager.sln
 
-    - name: Test
-      run: dotnet test --no-build --verbosity normal DBRManager.sln
+    - name: Test with coverage
+      run: dotnet test --no-build --collect:"XPlat Code Coverage" --results-directory ./TestResults DBRManager.sln
+
+    - name: Install ReportGenerator
+      run: dotnet tool update -g dotnet-reportgenerator-globaltool
+
+    - name: Generate coverage report
+      run: |
+        reportgenerator -reports:TestResults/**/coverage.cobertura.xml -targetdir:coveragereport -reporttypes:Html
+      env:
+        PATH: ${{ env.PATH }}:$HOME/.dotnet/tools
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-report
+        path: coveragereport


### PR DESCRIPTION
## Summary
- run tests with coverage
- generate HTML report with ReportGenerator
- upload coverage report as artifact

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef9fa918832c9895b3f5778ccd6d