### PR TITLE
Fix typo in variable name

### DIFF
--- a/src/Domain/ValueObjects/IidxId.cs
+++ b/src/Domain/ValueObjects/IidxId.cs
@@ -23,8 +23,8 @@ namespace Domain.ValueObjects
                 throw new ArgumentException("Invalid IidxId format.");
             }
 
-            var formatedValue = regex.Replace(value, "$1-$2").ConvertFullToHalfNumbers();
-            Value = formatedValue;
+            var formattedValue = regex.Replace(value, "$1-$2").ConvertFullToHalfNumbers();
+            Value = formattedValue;
         }
 
         [GeneratedRegex("^\\s*(\\d{4})-?(\\d{4})\\s*$")]


### PR DESCRIPTION
## Summary
- fix typo in `IidxId` value object

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f10a8688832c8880c6706a4b78c3