### PR TITLE
Fix StringExtensions modifier order

### DIFF
--- a/src/Domain/Modules/StringExtensions.cs
+++ b/src/Domain/Modules/StringExtensions.cs
@@ -2,14 +2,14 @@
 
 namespace Domain.Modules
 {
-    static internal partial class StringExtensions
+    internal static partial class StringExtensions
     {
         /// <summary>
         /// 全角数字を半角数字に変換する。
         /// </summary>
         /// <param name="value">変換する文字列</param>
         /// <returns>変換後の文字列</returns>
-        static public string ConvertFullToHalfNumbers(this string value)
+        public static string ConvertFullToHalfNumbers(this string value)
         {
             return FullNumbers().Replace(value, p => ((char)(p.Value[0] - '０' + '0')).ToString());
         }


### PR DESCRIPTION
## Summary
- adjust class and method modifiers to follow standard ordering
- keep existing functionality

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f29b0078832c96e90b6d82381ae8