### PR TITLE
Fix Score class closing brace

### DIFF
--- a/src/Domain/ValueObjects/Score.cs
+++ b/src/Domain/ValueObjects/Score.cs
@@ -13,5 +13,5 @@
             this.Bp = Bp;
             this.ComboBreak = ComboBreak;
         }
-    };
+    }
 }


### PR DESCRIPTION
## Summary
- close `Score` class definition properly

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f29a0e4c832c834eb936f1525481