### PR TITLE
Configure composite key for PlayerScore

### DIFF
--- a/src/Infrastructure/EFCore/ApplicationDbContext.cs
+++ b/src/Infrastructure/EFCore/ApplicationDbContext.cs
@@ -11,5 +11,18 @@ namespace Infrastructure.Repositories
         public DbSet<Player> Players { get; set; }
         public DbSet<PlayerScore> PlayerScores { get; set; }
         public DbSet<GameVersion> GameVersions { get; set; }
+
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<PlayerScore>()
+                .HasKey(ps => new { ps.PlayerId, ps.MusicId, ps.Difficulty, ps.PlayAt });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- override `OnModelCreating` in `ApplicationDbContext`
- configure composite key for `PlayerScore`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f29d82bc832c99479993607ad92e