### PR TITLE
global.json を追加して .NET 10 SDK を固定、ターゲットとCIを更新

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Restore dependencies
       run: dotnet restore DBRManager.sln

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Platforms>AnyCPU;x64</Platforms>

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/DomainTest/DomainTest.csproj
+++ b/tests/DomainTest/DomainTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
### Motivation
- プロジェクトとCIを .NET 10 に揃え、開発環境の一貫性と将来互換性を確保するためです。 
- ローカルとCIで使用するSDKバージョンを明示的に固定するために `global.json` を追加する必要がありました。 
- GitHub Actions とプロジェクトのターゲットフレームワークを一致させることでビルドの再現性を高めるためです。

### Description
- `global.json` を追加して SDK を `10.0.100` に固定し、`rollForward` を `latestFeature` に設定しました。 
- `src/Domain/Domain.csproj`、`src/Infrastructure/Infrastructure.csproj`、`tests/DomainTest/DomainTest.csproj` の `TargetFramework` を `net8.0` から `net10.0` に更新しました。 
- `.github/workflows/dotnet-test.yml` の `dotnet-version` を `'10.0.x'` に更新しました。

### Testing
- ローカルで自動テストは実行しておらず、`dotnet test` は未実行です。 
- CI ワークフローはリポジトリにコミット済みですが、GitHub 上でのワークフロー実行は未検証です。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696105d2f7fc832c874a213f09509a55)